### PR TITLE
Fixed exception table

### DIFF
--- a/src/attribute_info/parser.rs
+++ b/src/attribute_info/parser.rs
@@ -70,7 +70,7 @@ pub fn code_attribute_parser(input: &[u8]) -> IResult<&[u8], CodeAttribute> {
 pub fn exceptions_attribute_parser(input: &[u8]) -> IResult<&[u8], ExceptionsAttribute> {
     chain!(input,
         exception_table_length: be_u16 ~
-        exception_table: count!(exception_entry_parser, exception_table_length as usize),
+        exception_table: count!(be_u16, exception_table_length as usize),
         || {
             ExceptionsAttribute {
                 exception_table_length: exception_table_length,

--- a/src/attribute_info/types.rs
+++ b/src/attribute_info/types.rs
@@ -24,7 +24,7 @@ pub struct CodeAttribute {
 
 pub struct ExceptionsAttribute {
     pub exception_table_length: u16,
-    pub exception_table: Vec<ExceptionEntry>,
+    pub exception_table: Vec<u16>,
 }
 
 pub struct ConstantValueAttribute {


### PR DESCRIPTION
The Exception-Attribute contains only references to the constant pool, not ExceptionEntries. These are only found in Code-Attributes. See https://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7.5