### PR TITLE
Stop unconditionally emitting debugging information

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub fn parse_class(class_name: &str) -> Result<ClassFile, String> {
     let mut class_bytes = Vec::new();
     match file.read_to_end(&mut class_bytes) {
         Err(why) => return Err(format!("Unable to read {}: {}", display, Error::description(&why))),
-        Ok(_) => println!("{} contains {} bytes.", display, class_bytes.len()),
+        Ok(_) => {},
     };
 
     let parsed_class = class_parser(&class_bytes);


### PR DESCRIPTION
I like `classfile-parser` but I prefer that it not emit what is essentially debugging information via `println!()` at least without that behavior being configurable.

First I just removed the `println!()` completely but if you would like to see something with more finesse, please let me know.