### PR TITLE
Prefer `..=` over deprecated `...`

### DIFF
--- a/src/attribute_info/parser.rs
+++ b/src/attribute_info/parser.rs
@@ -169,12 +169,12 @@ fn full_frame_parser(input: &[u8], frame_type: u8) -> Result<(&[u8], StackMapFra
 
 fn stack_frame_parser(input: &[u8], frame_type: u8) -> Result<(&[u8], StackMapFrame), Err<&[u8]>> {
     match frame_type {
-        0...63 => same_frame_parser(input, frame_type),
-        64...127 => same_locals_1_stack_item_frame_parser(input, frame_type),
+        0..=63 => same_frame_parser(input, frame_type),
+        64..=127 => same_locals_1_stack_item_frame_parser(input, frame_type),
         247 => same_locals_1_stack_item_frame_extended_parser(input, frame_type),
-        248...250 => chop_frame_parser(input, frame_type),
+        248..=250 => chop_frame_parser(input, frame_type),
         251 => same_frame_extended_parser(input, frame_type),
-        252...254 => append_frame_parser(input, frame_type),
+        252..=254 => append_frame_parser(input, frame_type),
         255 => full_frame_parser(input, frame_type),
         _ => Result::Err(Err::Error(error_position!(input, ErrorKind::Custom(2)))),
     }


### PR DESCRIPTION
The `...` syntax for inclusive ranges has been [deprecated for some time](https://github.com/rust-lang/rust/issues/28237), and at least for me with Rust 1.41.1, it triggers deprecation warnings shown below.

    warning: `...` range patterns are deprecated
       --> src/attribute_info/parser.rs:172:10
        |
    172 |         0...63 => same_frame_parser(input, frame_type),
        |          ^^^ help: use `..=` for an inclusive range
        |
        = note: `#[warn(ellipsis_inclusive_range_patterns)]` on by default

    warning: `...` range patterns are deprecated
       --> src/attribute_info/parser.rs:173:11
        |
    173 |         64...127 => same_locals_1_stack_item_frame_parser(input, frame_type),
        |           ^^^ help: use `..=` for an inclusive range

    warning: `...` range patterns are deprecated
       --> src/attribute_info/parser.rs:175:12
        |
    175 |         248...250 => chop_frame_parser(input, frame_type),
        |            ^^^ help: use `..=` for an inclusive range

    warning: `...` range patterns are deprecated
       --> src/attribute_info/parser.rs:177:12
        |
    177 |         252...254 => append_frame_parser(input, frame_type),
        |            ^^^ help: use `..=` for an inclusive range
