### PR TITLE
Add the MIT license to the toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ categories = ["parser-implementations"]
 repository = "https://github.com/Palmr/classfile-parser"
 readme = "README.md"
 license-file = "LICENSE.txt"
+license = "MIT"
 exclude = [".idea/**/*", "classfile-parser.iml", "java-assets/out/**/*"]
 
 [badges]


### PR DESCRIPTION
Explicitly list the license to make integration with automated tools easier.