### PR TITLE
Use nom 5.1.3 to avoid future compilation failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ license = "MIT"
 exclude = [".idea/**/*", "classfile-parser.iml", "java-assets/out/**/*"]
 
 [dependencies]
-nom = "^4.1"
+nom = "5.1.3"
 bitflags = "^1.2"
 cesu8 = "^1.1"

--- a/src/attribute_info/parser.rs
+++ b/src/attribute_info/parser.rs
@@ -1,6 +1,7 @@
 use nom::{
+    error::ErrorKind,
     number::complete::{be_u16, be_u32, be_u8},
-    Err, ErrorKind,
+    Err,
 };
 
 use attribute_info::types::StackMapFrame::*;

--- a/src/attribute_info/parser.rs
+++ b/src/attribute_info/parser.rs
@@ -178,7 +178,7 @@ fn stack_frame_parser(input: &[u8], frame_type: u8) -> Result<(&[u8], StackMapFr
 fn stack_map_frame_entry_parser(input: &[u8]) -> Result<(&[u8], StackMapFrame), Err<&[u8]>> {
     do_parse!(
         input,
-        frame_type: be_u8 >> stack_frame: apply!(stack_frame_parser, frame_type) >> (stack_frame)
+        frame_type: be_u8 >> stack_frame: call!(stack_frame_parser, frame_type) >> (stack_frame)
     )
 }
 

--- a/src/attribute_info/parser.rs
+++ b/src/attribute_info/parser.rs
@@ -75,7 +75,7 @@ fn verification_type_parser(input: &[u8]) -> Result<(&[u8], VerificationTypeInfo
         6 => Ok((new_input, UninitializedThis)),
         7 => do_parse!(new_input, class: be_u16 >> (Object { class })),
         8 => do_parse!(new_input, offset: be_u16 >> (Uninitialized { offset })),
-        _ => Result::Err(Err::Error(error_position!(input, ErrorKind::Custom(1)))),
+        _ => Result::Err(Err::Error(error_position!(input, ErrorKind::NoneOf))),
     }
 }
 
@@ -171,7 +171,7 @@ fn stack_frame_parser(input: &[u8], frame_type: u8) -> Result<(&[u8], StackMapFr
         251 => same_frame_extended_parser(input, frame_type),
         252..=254 => append_frame_parser(input, frame_type),
         255 => full_frame_parser(input, frame_type),
-        _ => Result::Err(Err::Error(error_position!(input, ErrorKind::Custom(2)))),
+        _ => Result::Err(Err::Error(error_position!(input, ErrorKind::NoneOf))),
     }
 }
 

--- a/src/attribute_info/parser.rs
+++ b/src/attribute_info/parser.rs
@@ -1,4 +1,7 @@
-use nom::{be_u16, be_u32, be_u8, Err, ErrorKind};
+use nom::{
+    number::complete::{be_u16, be_u32, be_u8},
+    Err, ErrorKind,
+};
 
 use attribute_info::types::StackMapFrame::*;
 use attribute_info::*;

--- a/src/attribute_info/parser.rs
+++ b/src/attribute_info/parser.rs
@@ -1,11 +1,14 @@
 use nom::{
     error::ErrorKind,
     number::complete::{be_u16, be_u32, be_u8},
-    Err,
+    Err as BaseErr,
 };
 
 use attribute_info::types::StackMapFrame::*;
 use attribute_info::*;
+
+// Using a type alias here evades a Clippy warning about complex types.
+type Err<E> = BaseErr<(E, ErrorKind)>;
 
 pub fn attribute_parser(input: &[u8]) -> Result<(&[u8], AttributeInfo), Err<&[u8]>> {
     do_parse!(

--- a/src/code_attribute/parser.rs
+++ b/src/code_attribute/parser.rs
@@ -44,8 +44,8 @@ pub fn code_parser(input: &[u8]) -> IResult<&[u8], Vec<(usize, Instruction)>> {
     many0!(
         input,
         complete!(do_parse!(
-            address: apply!(offset, input)
-                >> instruction: apply!(instruction_parser, address)
+            address: call!(offset, input)
+                >> instruction: call!(instruction_parser, address)
                 >> (address, instruction)
         ))
     )
@@ -223,7 +223,7 @@ pub fn instruction_parser(input: &[u8], address: usize) -> IResult<&[u8], Instru
         0x21 => value!(Instruction::Lload3) |
         0x69 => value!(Instruction::Lmul) |
         0x75 => value!(Instruction::Lneg) |
-        0xab => preceded!(apply!(align, address + 1), lookupswitch_parser) |
+        0xab => preceded!(call!(align, address + 1), lookupswitch_parser) |
         0x81 => value!(Instruction::Lor) |
         0x71 => value!(Instruction::Lrem) |
         0xad => value!(Instruction::Lreturn) |
@@ -253,7 +253,7 @@ pub fn instruction_parser(input: &[u8], address: usize) -> IResult<&[u8], Instru
         0x56 => value!(Instruction::Sastore) |
         0x11 => map!(be_i16, Instruction::Sipush) |
         0x5f => value!(Instruction::Swap) |
-        0xaa => preceded!(apply!(align, address + 1), tableswitch_parser) |
+        0xaa => preceded!(call!(align, address + 1), tableswitch_parser) |
         0xc4 => switch!(be_u8,
             0x19 => map!(be_u16, Instruction::AloadWide) |
             0x3a => map!(be_u16, Instruction::AstoreWide) |

--- a/src/code_attribute/parser.rs
+++ b/src/code_attribute/parser.rs
@@ -10,15 +10,16 @@ fn align(input: &[u8], address: usize) -> IResult<&[u8], &[u8]> {
 }
 
 fn lookupswitch_parser(input: &[u8]) -> IResult<&[u8], Instruction> {
+    // This function provides type annotations required by rustc.
+    fn each_pair(input: &[u8]) -> IResult<&[u8], (i32, i32)> {
+        do_parse!(input, lookup: be_i32 >> offset: be_i32 >> (lookup, offset))
+    }
+
     do_parse!(
         input,
         default: be_i32
             >> npairs: be_u32
-            >> pairs:
-                count!(
-                    do_parse!(lookup: be_i32 >> offset: be_i32 >> (lookup, offset)),
-                    npairs as usize
-                )
+            >> pairs: count!(call!(each_pair), npairs as usize)
             >> (Instruction::Lookupswitch { default, pairs })
     )
 }

--- a/src/code_attribute/parser.rs
+++ b/src/code_attribute/parser.rs
@@ -1,5 +1,8 @@
 use code_attribute::types::Instruction;
-use nom::{be_i16, be_i32, be_i8, be_u16, be_u32, be_u8, IResult, Offset};
+use nom::{
+    number::complete::{be_i16, be_i32, be_i8, be_u16, be_u32, be_u8},
+    IResult, Offset,
+};
 
 fn offset<'a>(remaining: &'a [u8], input: &[u8]) -> IResult<&'a [u8], usize> {
     Ok((remaining, input.offset(remaining)))

--- a/src/constant_info/parser.rs
+++ b/src/constant_info/parser.rs
@@ -150,8 +150,8 @@ named!(const_invoke_dynamic<&[u8], ConstantInfo>, do_parse!(
     ))
 ));
 
-type ConstantInfoResult<'a> = Result<(&'a [u8], ConstantInfo), Err<&'a [u8], u32>>;
-type ConstantInfoVecResult<'a> = Result<(&'a [u8], Vec<ConstantInfo>), Err<&'a [u8], u32>>;
+type ConstantInfoResult<'a> = Result<(&'a [u8], ConstantInfo), Err<(&'a [u8], ErrorKind)>>;
+type ConstantInfoVecResult<'a> = Result<(&'a [u8], Vec<ConstantInfo>), Err<(&'a [u8], ErrorKind)>>;
 
 fn const_block_parser(input: &[u8], const_type: u8) -> ConstantInfoResult {
     match const_type {

--- a/src/constant_info/parser.rs
+++ b/src/constant_info/parser.rs
@@ -172,7 +172,7 @@ fn const_block_parser(input: &[u8], const_type: u8) -> ConstantInfoResult {
 fn single_constant_parser(input: &[u8]) -> ConstantInfoResult {
     do_parse!(
         input,
-        const_type: be_u8 >> const_block: apply!(const_block_parser, const_type) >> (const_block)
+        const_type: be_u8 >> const_block: call!(const_block_parser, const_type) >> (const_block)
     )
 }
 

--- a/src/constant_info/parser.rs
+++ b/src/constant_info/parser.rs
@@ -1,4 +1,7 @@
-use nom::{be_f32, be_f64, be_i32, be_i64, be_u16, be_u8, Err, ErrorKind};
+use nom::{
+    number::complete::{be_f32, be_f64, be_i32, be_i64, be_u16, be_u8},
+    Err, ErrorKind,
+};
 
 use constant_info::*;
 

--- a/src/constant_info/parser.rs
+++ b/src/constant_info/parser.rs
@@ -1,6 +1,7 @@
 use nom::{
+    error::ErrorKind,
     number::complete::{be_f32, be_f64, be_i32, be_i64, be_u16, be_u8},
-    Err, ErrorKind,
+    Err,
 };
 
 use constant_info::*;

--- a/src/field_info/parser.rs
+++ b/src/field_info/parser.rs
@@ -1,4 +1,4 @@
-use nom::{be_u16, IResult};
+use nom::{number::complete::be_u16, IResult};
 
 use attribute_info::attribute_parser;
 

--- a/src/method_info/parser.rs
+++ b/src/method_info/parser.rs
@@ -1,4 +1,4 @@
-use nom::{be_u16, IResult};
+use nom::{number::complete::be_u16, IResult};
 
 use attribute_info::attribute_parser;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -25,6 +25,7 @@ named!(magic_parser, tag!(&[0xCA, 0xFE, 0xBA, 0xBE]));
 /// };
 /// ```
 pub fn class_parser(input: &[u8]) -> IResult<&[u8], ClassFile> {
+    use nom::number::complete::be_u16;
     do_parse!(
         input,
         magic_parser

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -31,7 +31,7 @@ pub fn class_parser(input: &[u8]) -> IResult<&[u8], ClassFile> {
             >> minor_version: be_u16
             >> major_version: be_u16
             >> const_pool_size: be_u16
-            >> const_pool: apply!(constant_parser, (const_pool_size - 1) as usize)
+            >> const_pool: call!(constant_parser, (const_pool_size - 1) as usize)
             >> access_flags: be_u16
             >> this_class: be_u16
             >> super_class: be_u16


### PR DESCRIPTION
As of `classfile-parser`'s `master` branch at 6baefc0d69a4291742451bf47c848e02731ca8d6, nom major version 4 is used (version 4.2.3 in my `Cargo.lock`).

That version of `nom` fails at least one lint that will become hard failures in future rustc versions ("trailing semicolon in macro used in expression position" from https://github.com/rust-lang/rust/issues/79813).

[In nom 5.1.3, a fix for this was introduced](https://github.com/rust-bakery/nom/issues/1659#issuecomment-1524003544). Upgrading to nom 5's API required some changes; I stumbled into something that passes tests.

Notes:
- `apply!` does not seem to exist in nom 5; for these cases, `call!` works in nom 4.2.3 and in 5.1.3 apparently equally well;
- I did not know what `ErrorKind` to use in c680f06a04842066848415938af2e1813371b487, so I elected `NoneOf` ([newer nom has a generic `Fail`](https://github.com/rust-bakery/nom/commit/808a85bbcf84ae59b1040e82528e41f53b991920));
- It is not clear to me whether 74f1f52d9654f801d45d62a910cae2cbfc1848b9 newly leaks nom details in some way;
- I have not determined what effect this change has on MSRV;
- These changes pass `cargo test`, but I really do not know whether they constitute a good solution.

# Before
```
❯ cargo check
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
warning: the following packages contain code that will be rejected by a future version of Rust: nom v4.2.3
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`
```

<details>

```
❯ cargo check --future-incompat-report
    Finished dev [unoptimized + debuginfo] target(s) in 0.01s
warning: the following packages contain code that will be rejected by a future version of Rust: nom v4.2.3
note: 
To solve this problem, you can try the following approaches:


- Some affected dependencies have newer versions available.
You may want to consider updating them to a newer version to see if the issue has been fixed.

nom v4.2.3 has the following newer versions available: 5.0.0-alpha1, 5.0.0-alpha2, 5.0.0-beta1, 5.0.0-beta2, 5.0.0-beta3, 5.0.0, 5.0.1, 5.1.0, 5.1.1, 5.1.2, 5.1.3, 6.0.0-alpha1, 6.0.0-alpha2, 6.0.0-alpha3, 6.0.0-beta1, 6.0.0-beta2, 6.0.0-beta3, 6.0.0-beta4, 6.0.0-beta5, 6.0.0, 6.0.1, 6.1.0, 6.1.1, 6.1.2, 6.2.0, 6.2.1, 6.2.2, 7.0.0-alpha1, 7.0.0-alpha2, 7.0.0-alpha3, 7.0.0, 7.1.0, 7.1.1, 7.1.2, 7.1.3


- If the issue is not solved by updating the dependencies, a fix has to be
implemented by those dependencies. You can help with that by notifying the
maintainers of this problem (e.g. by creating a bug report) or by proposing a
fix to the maintainers (e.g. by creating a pull request):

  - nom@4.2.3
  - Repository: https://github.com/Geal/nom
  - Detailed warning command: `cargo report future-incompatibilities --id 2 --package nom@4.2.3`

- If waiting for an upstream fix is not an option, you can use the `[patch]`
section in `Cargo.toml` to use your own version of the dependency. For more
information, see:
https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
        
note: this report can be shown with `cargo report future-incompatibilities --id 1`

```

```
❯ cargo report future-incompatibilities --id 1 | grep -m1 warning: -A16
> warning: trailing semicolon in macro used in expression position
>    --> /Users/kulp/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nom-4.2.3/src/macros.rs:666:35
>     |
> 666 |     map!(__impl $i, call!($f), $g);
>     |                                   ^
>     |
>    ::: /Users/kulp/.cargo/registry/src/index.crates.io-6f17d22bba15001f/nom-4.2.3/src/nom.rs:495:3
>     |
> 495 |   map!(i, be_u8, |x| x as i8)
>     |   --------------------------- in this macro invocation
>     |
>     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
>     = note: for more information, see issue #79813 <https://github.com/rust-lang/rust/issues/79813>
>     = note: macro invocations at the end of a block are treated as expressions
>     = note: to ignore the value produced by the macro, add a semicolon after the invocation of `map`
>     = note: `#[allow(semicolon_in_expressions_from_macros)]` on by default
>     = note: this warning originates in the macro `map` (in Nightly builds, run with -Z macro-backtrace for more info)
```

</details>

# After
```
❯ cargo check --future-incompat-report
    Updating crates.io index
    Checking nom v5.1.3
    Checking classfile-parser v0.3.6 (/private/var/folders/x5/z29gc2pj4qq9wgkcm6_lw_hc0000gn/T/tmp.tAKVAyXR/classfile-parser)
    Finished dev [unoptimized + debuginfo] target(s) in 2.27s
note: 0 dependencies had future-incompatible warnings
```