### PR TITLE
Appease clippy, again

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub fn parse_class(class_name: &str) -> Result<ClassFile, String> {
     let path = Path::new(class_file_name);
     let display = path.display();
 
-    let mut file = match File::open(&path) {
+    let mut file = match File::open(path) {
         Err(why) => {
             return Err(format!("Unable to open {}: {}", display, &why.to_string()));
         }

--- a/tests/code_attribute.rs
+++ b/tests/code_attribute.rs
@@ -76,6 +76,6 @@ fn test_class() {
 
     let parsed = code_parser(&code_attribute.code);
 
-    assert_eq!(true, parsed.is_ok());
+    assert!(parsed.is_ok());
     assert_eq!(64, parsed.unwrap().1.len());
 }


### PR DESCRIPTION
These changes are meant to allow #31 to pass CI, once #31 is rebased upon the current PR.

These changes were made automatically by:

    cargo clippy --fix

as of clippy version:

    clippy 0.1.69 (84c898d6 2023-04-16)