### PR TITLE
Add parse_class_from_reader function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,7 @@ pub mod types;
 pub use parser::class_parser;
 pub use types::*;
 
-/// Attempt to parse a class file given a class file given a path to a class file
-/// (without .class extension)
+/// Attempt to parse a class file given a path to a class file (without .class extension)
 ///
 /// ```rust
 /// match classfile_parser::parse_class("./java-assets/compiled-classes/BasicClass") {
@@ -50,6 +49,15 @@ pub fn parse_class(class_name: &str) -> Result<ClassFile, String> {
     parse_class_from_reader(&mut reader, display.to_string())
 }
 
+/// Attempt to parse a class file given a reader that implements the std::io::Read trait.
+/// The file_path parameter is only used in case of errors to provide reasonable error
+/// messages.
+///
+/// ```rust
+/// let mut reader = "this_will_be_parsed_as_classfile".as_bytes();
+/// let result = classfile_parser::parse_class_from_reader(&mut reader, "path/to/Java.class".to_string());
+/// assert!(result.is_err());
+/// ```
 pub fn parse_class_from_reader<T: Read>(
     reader: &mut T,
     file_path: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! A parser for [Java Classfiles](https://docs.oracle.com/javase/specs/jvms/se10/html/jvms-4.html)
 
 use std::fs::File;
-use std::io::prelude::*;
+use std::io::{prelude::*, BufReader};
 use std::path::Path;
 
 #[macro_use]
@@ -39,21 +39,33 @@ pub fn parse_class(class_name: &str) -> Result<ClassFile, String> {
     let path = Path::new(class_file_name);
     let display = path.display();
 
-    let mut file = match File::open(path) {
+    let file = match File::open(path) {
         Err(why) => {
             return Err(format!("Unable to open {}: {}", display, &why.to_string()));
         }
         Ok(file) => file,
     };
 
+    let mut reader = BufReader::new(file);
+    parse_class_from_reader(&mut reader, display.to_string())
+}
+
+pub fn parse_class_from_reader<T: Read>(
+    reader: &mut T,
+    file_path: String,
+) -> Result<ClassFile, String> {
     let mut class_bytes = Vec::new();
-    if let Err(why) = file.read_to_end(&mut class_bytes) {
-        return Err(format!("Unable to read {}: {}", display, &why.to_string()));
+    if let Err(why) = reader.read_to_end(&mut class_bytes) {
+        return Err(format!(
+            "Unable to read {}: {}",
+            file_path,
+            &why.to_string()
+        ));
     }
 
     let parsed_class = class_parser(&class_bytes);
     match parsed_class {
         Ok((_, c)) => Ok(c),
-        _ => Err("Failed to parse class?".to_string()),
+        _ => Err(format!("Failed to parse classfile {}", file_path)),
     }
 }


### PR DESCRIPTION
Adding a separate parse_class_from_reader function similar to parse_class function. The new function is more versatile because any reader can be used. For instance, also files/bytes directly from an in-memory (jar) archives can be used as source.