### PR TITLE
Upgrade to nom 7 to get a clean rustsec audit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ license = "MIT"
 exclude = [".idea/**/*", "classfile-parser.iml", "java-assets/out/**/*"]
 
 [dependencies]
-nom = "6"
+nom = "7"
 bitflags = "^2.3"
 cesu8 = "^1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,6 @@ license = "MIT"
 exclude = [".idea/**/*", "classfile-parser.iml", "java-assets/out/**/*"]
 
 [dependencies]
-nom = "5.1.3"
+nom = "6"
 bitflags = "^2.3"
 cesu8 = "^1.1"

--- a/src/attribute_info/parser.rs
+++ b/src/attribute_info/parser.rs
@@ -1,5 +1,8 @@
 use nom::{
+    bytes::complete::take,
+    combinator::{map, success},
     error::{Error, ErrorKind},
+    multi::count,
     number::complete::{be_u16, be_u32, be_u8},
     Err as BaseErr,
 };
@@ -11,87 +14,88 @@ use attribute_info::*;
 type Err<E> = BaseErr<Error<E>>;
 
 pub fn attribute_parser(input: &[u8]) -> Result<(&[u8], AttributeInfo), Err<&[u8]>> {
-    do_parse!(
+    let (input, attribute_name_index) = be_u16(input)?;
+    let (input, attribute_length) = be_u32(input)?;
+    let (input, info) = take(attribute_length)(input)?;
+    Ok((
         input,
-        attribute_name_index: be_u16
-            >> attribute_length: be_u32
-            >> info: take!(attribute_length)
-            >> (AttributeInfo {
-                attribute_name_index,
-                attribute_length,
-                info: info.to_owned(),
-            })
-    )
+        AttributeInfo {
+            attribute_name_index,
+            attribute_length,
+            info: info.to_owned(),
+        },
+    ))
 }
 
 pub fn exception_entry_parser(input: &[u8]) -> Result<(&[u8], ExceptionEntry), Err<&[u8]>> {
-    do_parse!(
+    let (input, start_pc) = be_u16(input)?;
+    let (input, end_pc) = be_u16(input)?;
+    let (input, handler_pc) = be_u16(input)?;
+    let (input, catch_type) = be_u16(input)?;
+    Ok((
         input,
-        start_pc: be_u16
-            >> end_pc: be_u16
-            >> handler_pc: be_u16
-            >> catch_type: be_u16
-            >> (ExceptionEntry {
-                start_pc,
-                end_pc,
-                handler_pc,
-                catch_type,
-            })
-    )
+        ExceptionEntry {
+            start_pc,
+            end_pc,
+            handler_pc,
+            catch_type,
+        },
+    ))
 }
 
 pub fn code_attribute_parser(input: &[u8]) -> Result<(&[u8], CodeAttribute), Err<&[u8]>> {
-    do_parse!(
+    let (input, max_stack) = be_u16(input)?;
+    let (input, max_locals) = be_u16(input)?;
+    let (input, code_length) = be_u32(input)?;
+    let (input, code) = take(code_length)(input)?;
+    let (input, exception_table_length) = be_u16(input)?;
+    let (input, exception_table) =
+        count(exception_entry_parser, exception_table_length as usize)(input)?;
+    let (input, attributes_count) = be_u16(input)?;
+    let (input, attributes) = count(attribute_parser, attributes_count as usize)(input)?;
+    Ok((
         input,
-        max_stack: be_u16
-            >> max_locals: be_u16
-            >> code_length: be_u32
-            >> code: take!(code_length)
-            >> exception_table_length: be_u16
-            >> exception_table: count!(exception_entry_parser, exception_table_length as usize)
-            >> attributes_count: be_u16
-            >> attributes: count!(attribute_parser, attributes_count as usize)
-            >> (CodeAttribute {
-                max_stack,
-                max_locals,
-                code_length,
-                code: code.to_owned(),
-                exception_table_length,
-                exception_table,
-                attributes_count,
-                attributes,
-            })
-    )
+        CodeAttribute {
+            max_stack,
+            max_locals,
+            code_length,
+            code: code.to_owned(),
+            exception_table_length,
+            exception_table,
+            attributes_count,
+            attributes,
+        },
+    ))
 }
 
 pub fn method_parameters_attribute_parser(
     input: &[u8],
 ) -> Result<(&[u8], MethodParametersAttribute), Err<&[u8]>> {
-    do_parse!(
+    let (input, parameters_count) = be_u8(input)?;
+    let (input, parameters) = count(parameters_parser, parameters_count as usize)(input)?;
+    Ok((
         input,
-            parameters_count: be_u8
-            >> parameters: count!(parameters_parser, parameters_count as usize)
-            >> (MethodParametersAttribute {
-                parameters_count,
-                parameters,
-            })
-    )
+        MethodParametersAttribute {
+            parameters_count,
+            parameters,
+        },
+    ))
 }
 
 pub fn parameters_parser(input: &[u8]) -> Result<(&[u8], ParameterAttribute), Err<&[u8]>> {
-    do_parse!(
+    let (input, name_index) = be_u16(input)?;
+    let (input, access_flags) = be_u16(input)?;
+    Ok((
         input,
-        name_index: be_u16
-            >> access_flags: be_u16
-            >> (ParameterAttribute {
-                name_index,
-                access_flags
-            })
-    )
+        ParameterAttribute {
+            name_index,
+            access_flags,
+        },
+    ))
 }
 
 fn same_frame_parser(input: &[u8], frame_type: u8) -> Result<(&[u8], StackMapFrame), Err<&[u8]>> {
-    value!(input, SameFrame { frame_type })
+    success(SameFrame { frame_type })(input)
 }
 
 fn verification_type_parser(input: &[u8]) -> Result<(&[u8], VerificationTypeInfo), Err<&[u8]>> {
@@ -106,8 +110,8 @@ fn verification_type_parser(input: &[u8]) -> Result<(&[u8], VerificationTypeInfo
         4 => Ok((new_input, Long)),
         5 => Ok((new_input, Null)),
         6 => Ok((new_input, UninitializedThis)),
-        7 => do_parse!(new_input, class: be_u16 >> (Object { class })),
-        8 => do_parse!(new_input, offset: be_u16 >> (Uninitialized { offset })),
+        7 => map(be_u16, |class| Object { class })(new_input),
+        8 => map(be_u16, |offset| Uninitialized { offset })(new_input),
         _ => Result::Err(Err::Error(error_position!(input, ErrorKind::NoneOf))),
     }
 }
@@ -116,83 +120,81 @@ fn same_locals_1_stack_item_frame_parser(
     input: &[u8],
     frame_type: u8,
 ) -> Result<(&[u8], StackMapFrame), Err<&[u8]>> {
-    do_parse!(
-        input,
-        stack: verification_type_parser >> (SameLocals1StackItemFrame { frame_type, stack })
-    )
+    let (input, stack) = verification_type_parser(input)?;
+    Ok((input, SameLocals1StackItemFrame { frame_type, stack }))
 }
 
 fn same_locals_1_stack_item_frame_extended_parser(
     input: &[u8],
     frame_type: u8,
 ) -> Result<(&[u8], StackMapFrame), Err<&[u8]>> {
-    do_parse!(
+    let (input, offset_delta) = be_u16(input)?;
+    let (input, stack) = verification_type_parser(input)?;
+    Ok((
         input,
-        offset_delta: be_u16
-            >> stack: verification_type_parser
-            >> (SameLocals1StackItemFrameExtended {
-                frame_type,
-                offset_delta,
-                stack
-            })
-    )
+        SameLocals1StackItemFrameExtended {
+            frame_type,
+            offset_delta,
+            stack,
+        },
+    ))
 }
 
 fn chop_frame_parser(input: &[u8], frame_type: u8) -> Result<(&[u8], StackMapFrame), Err<&[u8]>> {
-    do_parse!(
+    let (input, offset_delta) = be_u16(input)?;
+    Ok((
         input,
-        offset_delta: be_u16
-            >> (ChopFrame {
-                frame_type,
-                offset_delta
-            })
-    )
+        ChopFrame {
+            frame_type,
+            offset_delta,
+        },
+    ))
 }
 
 fn same_frame_extended_parser(
     input: &[u8],
     frame_type: u8,
 ) -> Result<(&[u8], StackMapFrame), Err<&[u8]>> {
-    do_parse!(
+    let (input, offset_delta) = be_u16(input)?;
+    Ok((
         input,
-        offset_delta: be_u16
-            >> (SameFrameExtended {
-                frame_type,
-                offset_delta
-            })
-    )
+        SameFrameExtended {
+            frame_type,
+            offset_delta,
+        },
+    ))
 }
 
 fn append_frame_parser(input: &[u8], frame_type: u8) -> Result<(&[u8], StackMapFrame), Err<&[u8]>> {
-    do_parse!(
+    let (input, offset_delta) = be_u16(input)?;
+    let (input, locals) = count(verification_type_parser, (frame_type - 251) as usize)(input)?;
+    Ok((
         input,
-        offset_delta: be_u16
-            >> locals: count!(verification_type_parser, (frame_type - 251) as usize)
-            >> (AppendFrame {
-                frame_type,
-                offset_delta,
-                locals
-            })
-    )
+        AppendFrame {
+            frame_type,
+            offset_delta,
+            locals,
+        },
+    ))
 }
 
 fn full_frame_parser(input: &[u8], frame_type: u8) -> Result<(&[u8], StackMapFrame), Err<&[u8]>> {
-    do_parse!(
+    let (input, offset_delta) = be_u16(input)?;
+    let (input, number_of_locals) = be_u16(input)?;
+    let (input, locals) = count(verification_type_parser, number_of_locals as usize)(input)?;
+    let (input, number_of_stack_items) = be_u16(input)?;
+    let (input, stack) = count(verification_type_parser, number_of_stack_items as usize)(input)?;
+    Ok((
         input,
-        offset_delta: be_u16
-            >> number_of_locals: be_u16
-            >> locals: count!(verification_type_parser, number_of_locals as usize)
-            >> number_of_stack_items: be_u16
-            >> stack: count!(verification_type_parser, number_of_stack_items as usize)
-            >> (FullFrame {
-                frame_type,
-                offset_delta,
-                number_of_locals,
-                locals,
-                number_of_stack_items,
-                stack,
-            })
-    )
+        FullFrame {
+            frame_type,
+            offset_delta,
+            number_of_locals,
+            locals,
+            number_of_stack_items,
+            stack,
+        },
+    ))
 }
 
 fn stack_frame_parser(input: &[u8], frame_type: u8) -> Result<(&[u8], StackMapFrame), Err<&[u8]>> {
@@ -209,92 +211,92 @@ fn stack_frame_parser(input: &[u8], frame_type: u8) -> Result<(&[u8], StackMapFr
 }
 
 fn stack_map_frame_entry_parser(input: &[u8]) -> Result<(&[u8], StackMapFrame), Err<&[u8]>> {
-    do_parse!(
-        input,
-        frame_type: be_u8 >> stack_frame: call!(stack_frame_parser, frame_type) >> (stack_frame)
-    )
+    let (input, frame_type) = be_u8(input)?;
+    let (input, stack_frame) = stack_frame_parser(input, frame_type)?;
+    Ok((input, stack_frame))
 }
 
 pub fn stack_map_table_attribute_parser(
     input: &[u8],
 ) -> Result<(&[u8], StackMapTableAttribute), Err<&[u8]>> {
-    do_parse!(
+    let (input, number_of_entries) = be_u16(input)?;
+    let (input, entries) = count(stack_map_frame_entry_parser, number_of_entries as usize)(input)?;
+    Ok((
         input,
-        number_of_entries: be_u16
-            >> entries: count!(stack_map_frame_entry_parser, number_of_entries as usize)
-            >> (StackMapTableAttribute {
-                number_of_entries,
-                entries,
-            })
-    )
+        StackMapTableAttribute {
+            number_of_entries,
+            entries,
+        },
+    ))
 }
 
 pub fn exceptions_attribute_parser(
     input: &[u8],
 ) -> Result<(&[u8], ExceptionsAttribute), Err<&[u8]>> {
-    do_parse!(
+    let (input, exception_table_length) = be_u16(input)?;
+    let (input, exception_table) = count(be_u16, exception_table_length as usize)(input)?;
+    Ok((
         input,
-        exception_table_length: be_u16
-            >> exception_table: count!(be_u16, exception_table_length as usize)
-            >> (ExceptionsAttribute {
-                exception_table_length,
-                exception_table,
-            })
-    )
+        ExceptionsAttribute {
+            exception_table_length,
+            exception_table,
+        },
+    ))
 }
 
 pub fn constant_value_attribute_parser(
     input: &[u8],
 ) -> Result<(&[u8], ConstantValueAttribute), Err<&[u8]>> {
-    do_parse!(
+    let (input, constant_value_index) = be_u16(input)?;
+    Ok((
         input,
-        constant_value_index: be_u16
-            >> (ConstantValueAttribute {
-                constant_value_index,
-            })
-    )
+        ConstantValueAttribute {
+            constant_value_index,
+        },
+    ))
 }
 
 fn bootstrap_method_parser(input: &[u8]) -> Result<(&[u8], BootstrapMethod), Err<&[u8]>> {
-    do_parse!(
+    let (input, bootstrap_method_ref) = be_u16(input)?;
+    let (input, num_bootstrap_arguments) = be_u16(input)?;
+    let (input, bootstrap_arguments) = count(be_u16, num_bootstrap_arguments as usize)(input)?;
+    Ok((
         input,
-        bootstrap_method_ref: be_u16
-            >> num_bootstrap_arguments: be_u16
-            >> bootstrap_arguments: count!(be_u16, num_bootstrap_arguments as usize)
-            >> (BootstrapMethod {
-                bootstrap_method_ref,
-                num_bootstrap_arguments,
-                bootstrap_arguments,
-            })
-    )
+        BootstrapMethod {
+            bootstrap_method_ref,
+            num_bootstrap_arguments,
+            bootstrap_arguments,
+        },
+    ))
 }
 
 pub fn bootstrap_methods_attribute_parser(
     input: &[u8],
 ) -> Result<(&[u8], BootstrapMethodsAttribute), Err<&[u8]>> {
-    do_parse!(
+    let (input, num_bootstrap_methods) = be_u16(input)?;
+    let (input, bootstrap_methods) =
+        count(bootstrap_method_parser, num_bootstrap_methods as usize)(input)?;
+    Ok((
         input,
-        num_bootstrap_methods: be_u16
-            >> bootstrap_methods: count!(bootstrap_method_parser, num_bootstrap_methods as usize)
-            >> (BootstrapMethodsAttribute {
-                num_bootstrap_methods,
-                bootstrap_methods,
-            })
-    )
+        BootstrapMethodsAttribute {
+            num_bootstrap_methods,
+            bootstrap_methods,
+        },
+    ))
 }
 
 pub fn sourcefile_attribute_parser(
     input: &[u8],
 ) -> Result<(&[u8], SourceFileAttribute), Err<&[u8]>> {
-    do_parse!(
+    let (input, attribute_name_index) = be_u16(input)?;
+    let (input, attribute_length) = be_u32(input)?;
+    let (input, sourcefile_index) = be_u16(input)?;
+    Ok((
         input,
-        attribute_name_index: be_u16
-            >> attribute_length: be_u32
-            >> sourcefile_index: be_u16
-            >> (SourceFileAttribute {
-                attribute_name_index,
-                attribute_length,
-                sourcefile_index
-            })
-    )
+        SourceFileAttribute {
+            attribute_name_index,
+            attribute_length,
+            sourcefile_index,
+        },
+    ))
 }

--- a/src/attribute_info/parser.rs
+++ b/src/attribute_info/parser.rs
@@ -1,5 +1,5 @@
 use nom::{
-    error::ErrorKind,
+    error::{Error, ErrorKind},
     number::complete::{be_u16, be_u32, be_u8},
     Err as BaseErr,
 };
@@ -8,7 +8,7 @@ use attribute_info::types::StackMapFrame::*;
 use attribute_info::*;
 
 // Using a type alias here evades a Clippy warning about complex types.
-type Err<E> = BaseErr<(E, ErrorKind)>;
+type Err<E> = BaseErr<Error<E>>;
 
 pub fn attribute_parser(input: &[u8]) -> Result<(&[u8], AttributeInfo), Err<&[u8]>> {
     do_parse!(

--- a/src/constant_info/parser.rs
+++ b/src/constant_info/parser.rs
@@ -1,5 +1,5 @@
 use nom::{
-    error::ErrorKind,
+    error::{Error, ErrorKind},
     number::complete::{be_f32, be_f64, be_i32, be_i64, be_u16, be_u8},
     Err,
 };
@@ -150,8 +150,8 @@ named!(const_invoke_dynamic<&[u8], ConstantInfo>, do_parse!(
     ))
 ));
 
-type ConstantInfoResult<'a> = Result<(&'a [u8], ConstantInfo), Err<(&'a [u8], ErrorKind)>>;
-type ConstantInfoVecResult<'a> = Result<(&'a [u8], Vec<ConstantInfo>), Err<(&'a [u8], ErrorKind)>>;
+type ConstantInfoResult<'a> = Result<(&'a [u8], ConstantInfo), Err<Error<&'a [u8]>>>;
+type ConstantInfoVecResult<'a> = Result<(&'a [u8], Vec<ConstantInfo>), Err<Error<&'a [u8]>>>;
 
 fn const_block_parser(input: &[u8], const_type: u8) -> ConstantInfoResult {
     match const_type {

--- a/src/constant_info/parser.rs
+++ b/src/constant_info/parser.rs
@@ -1,4 +1,6 @@
 use nom::{
+    bytes::complete::take,
+    combinator::map,
     error::{Error, ErrorKind},
     number::complete::{be_f32, be_f64, be_i32, be_i64, be_u16, be_u8},
     Err,
@@ -15,140 +17,121 @@ fn utf8_constant(input: &[u8]) -> Utf8Constant {
     }
 }
 
-named!(const_utf8<&[u8], ConstantInfo>, do_parse!(
-    length: be_u16 >>
-    constant: map!(take!(length), utf8_constant) >>
-    (ConstantInfo::Utf8(constant))
-));
+fn const_utf8(input: &[u8]) -> ConstantInfoResult {
+    let (input, length) = be_u16(input)?;
+    let (input, constant) = map(take(length), utf8_constant)(input)?;
+    Ok((input, ConstantInfo::Utf8(constant)))
+}
 
-named!(const_integer<&[u8], ConstantInfo>, do_parse!(
-    value: be_i32 >>
-    (ConstantInfo::Integer(
-        IntegerConstant {
-            value,
-        }
-    ))
-));
+fn const_integer(input: &[u8]) -> ConstantInfoResult {
+    let (input, value) = be_i32(input)?;
+    Ok((input, ConstantInfo::Integer(IntegerConstant { value })))
+}
 
-named!(const_float<&[u8], ConstantInfo>, do_parse!(
-    value: be_f32 >>
-    (ConstantInfo::Float(
-        FloatConstant {
-            value,
-        }
-    ))
-));
+fn const_float(input: &[u8]) -> ConstantInfoResult {
+    let (input, value) = be_f32(input)?;
+    Ok((input, ConstantInfo::Float(FloatConstant { value })))
+}
 
-named!(const_long<&[u8], ConstantInfo>, do_parse!(
-    value: be_i64 >>
-    (ConstantInfo::Long(
-        LongConstant {
-            value,
-        }
-    ))
-));
+fn const_long(input: &[u8]) -> ConstantInfoResult {
+    let (input, value) = be_i64(input)?;
+    Ok((input, ConstantInfo::Long(LongConstant { value })))
+}
 
-named!(const_double<&[u8], ConstantInfo>, do_parse!(
-    value: be_f64 >>
-    (ConstantInfo::Double(
-        DoubleConstant {
-            value,
-        }
-    ))
-));
+fn const_double(input: &[u8]) -> ConstantInfoResult {
+    let (input, value) = be_f64(input)?;
+    Ok((input, ConstantInfo::Double(DoubleConstant { value })))
+}
 
-named!(const_class<&[u8], ConstantInfo>, do_parse!(
-    name_index: be_u16 >>
-    (ConstantInfo::Class(
-        ClassConstant {
-            name_index,
-        }
-    ))
-));
+fn const_class(input: &[u8]) -> ConstantInfoResult {
+    let (input, name_index) = be_u16(input)?;
+    Ok((input, ConstantInfo::Class(ClassConstant { name_index })))
+}
 
-named!(const_string<&[u8], ConstantInfo>, do_parse!(
-    string_index: be_u16 >>
-    (ConstantInfo::String(
-        StringConstant {
-            string_index,
-        }
-    ))
-));
+fn const_string(input: &[u8]) -> ConstantInfoResult {
+    let (input, string_index) = be_u16(input)?;
+    Ok((input, ConstantInfo::String(StringConstant { string_index })))
+}
 
-named!(const_field_ref<&[u8], ConstantInfo>, do_parse!(
-    class_index: be_u16 >>
-    name_and_type_index: be_u16 >>
-    (ConstantInfo::FieldRef(
-        FieldRefConstant {
+fn const_field_ref(input: &[u8]) -> ConstantInfoResult {
+    let (input, class_index) = be_u16(input)?;
+    let (input, name_and_type_index) = be_u16(input)?;
+    Ok((
+        input,
+        ConstantInfo::FieldRef(FieldRefConstant {
             class_index,
             name_and_type_index,
-        }
+        }),
     ))
-));
+}
 
-named!(const_method_ref<&[u8], ConstantInfo>, do_parse!(
-    class_index: be_u16 >>
-    name_and_type_index: be_u16 >>
-    (ConstantInfo::MethodRef(
-        MethodRefConstant {
+fn const_method_ref(input: &[u8]) -> ConstantInfoResult {
+    let (input, class_index) = be_u16(input)?;
+    let (input, name_and_type_index) = be_u16(input)?;
+    Ok((
+        input,
+        ConstantInfo::MethodRef(MethodRefConstant {
             class_index,
             name_and_type_index,
-        }
+        }),
     ))
-));
+}
 
-named!(const_interface_method_ref<&[u8], ConstantInfo>, do_parse!(
-    class_index: be_u16 >>
-    name_and_type_index: be_u16 >>
-    (ConstantInfo::InterfaceMethodRef(
-        InterfaceMethodRefConstant {
+fn const_interface_method_ref(input: &[u8]) -> ConstantInfoResult {
+    let (input, class_index) = be_u16(input)?;
+    let (input, name_and_type_index) = be_u16(input)?;
+    Ok((
+        input,
+        ConstantInfo::InterfaceMethodRef(InterfaceMethodRefConstant {
             class_index,
             name_and_type_index,
-        }
+        }),
     ))
-));
+}
 
-named!(const_name_and_type<&[u8], ConstantInfo>, do_parse!(
-    name_index: be_u16 >>
-    descriptor_index: be_u16 >>
-    (ConstantInfo::NameAndType(
-        NameAndTypeConstant {
+fn const_name_and_type(input: &[u8]) -> ConstantInfoResult {
+    let (input, name_index) = be_u16(input)?;
+    let (input, descriptor_index) = be_u16(input)?;
+    Ok((
+        input,
+        ConstantInfo::NameAndType(NameAndTypeConstant {
             name_index,
             descriptor_index,
-        }
+        }),
     ))
-));
+}
 
-named!(const_method_handle<&[u8], ConstantInfo>, do_parse!(
-    reference_kind: be_u8 >>
-    reference_index: be_u16 >>
-    (ConstantInfo::MethodHandle(
-        MethodHandleConstant {
+fn const_method_handle(input: &[u8]) -> ConstantInfoResult {
+    let (input, reference_kind) = be_u8(input)?;
+    let (input, reference_index) = be_u16(input)?;
+    Ok((
+        input,
+        ConstantInfo::MethodHandle(MethodHandleConstant {
             reference_kind,
             reference_index,
-        }
+        }),
     ))
-));
+}
 
-named!(const_method_type<&[u8], ConstantInfo>, do_parse!(
-    descriptor_index: be_u16 >>
-    (ConstantInfo::MethodType(
-        MethodTypeConstant {
-            descriptor_index,
-        }
+fn const_method_type(input: &[u8]) -> ConstantInfoResult {
+    let (input, descriptor_index) = be_u16(input)?;
+    Ok((
+        input,
+        ConstantInfo::MethodType(MethodTypeConstant { descriptor_index }),
     ))
-));
+}
 
-named!(const_invoke_dynamic<&[u8], ConstantInfo>, do_parse!(
-    bootstrap_method_attr_index: be_u16 >>
-    name_and_type_index: be_u16 >>
-    (ConstantInfo::InvokeDynamic(
-        InvokeDynamicConstant {
+fn const_invoke_dynamic(input: &[u8]) -> ConstantInfoResult {
+    let (input, bootstrap_method_attr_index) = be_u16(input)?;
+    let (input, name_and_type_index) = be_u16(input)?;
+    Ok((
+        input,
+        ConstantInfo::InvokeDynamic(InvokeDynamicConstant {
             bootstrap_method_attr_index,
             name_and_type_index,
-        }
+        }),
     ))
-));
+}
 
 type ConstantInfoResult<'a> = Result<(&'a [u8], ConstantInfo), Err<Error<&'a [u8]>>>;
 type ConstantInfoVecResult<'a> = Result<(&'a [u8], Vec<ConstantInfo>), Err<Error<&'a [u8]>>>;
@@ -174,10 +157,9 @@ fn const_block_parser(input: &[u8], const_type: u8) -> ConstantInfoResult {
 }
 
 fn single_constant_parser(input: &[u8]) -> ConstantInfoResult {
-    do_parse!(
-        input,
-        const_type: be_u8 >> const_block: call!(const_block_parser, const_type) >> (const_block)
-    )
+    let (input, const_type) = be_u8(input)?;
+    let (input, const_block) = const_block_parser(input, const_type)?;
+    Ok((input, const_block))
 }
 
 pub fn constant_parser(i: &[u8], const_pool_size: usize) -> ConstantInfoVecResult {

--- a/src/field_info/parser.rs
+++ b/src/field_info/parser.rs
@@ -1,23 +1,23 @@
-use nom::{number::complete::be_u16, IResult};
+use nom::{multi::count, number::complete::be_u16, IResult};
 
 use attribute_info::attribute_parser;
 
 use field_info::{FieldAccessFlags, FieldInfo};
 
 pub fn field_parser(input: &[u8]) -> IResult<&[u8], FieldInfo> {
-    do_parse!(
+    let (input, access_flags) = be_u16(input)?;
+    let (input, name_index) = be_u16(input)?;
+    let (input, descriptor_index) = be_u16(input)?;
+    let (input, attributes_count) = be_u16(input)?;
+    let (input, attributes) = count(attribute_parser, attributes_count as usize)(input)?;
+    Ok((
         input,
-        access_flags: be_u16
-            >> name_index: be_u16
-            >> descriptor_index: be_u16
-            >> attributes_count: be_u16
-            >> attributes: count!(attribute_parser, attributes_count as usize)
-            >> (FieldInfo {
-                access_flags: FieldAccessFlags::from_bits_truncate(access_flags),
-                name_index,
-                descriptor_index,
-                attributes_count,
-                attributes,
-            })
-    )
+        FieldInfo {
+            access_flags: FieldAccessFlags::from_bits_truncate(access_flags),
+            name_index,
+            descriptor_index,
+            attributes_count,
+            attributes,
+        },
+    ))
 }

--- a/src/method_info/parser.rs
+++ b/src/method_info/parser.rs
@@ -1,23 +1,23 @@
-use nom::{number::complete::be_u16, IResult};
+use nom::{multi::count, number::complete::be_u16, IResult};
 
 use attribute_info::attribute_parser;
 
 use method_info::{MethodAccessFlags, MethodInfo};
 
 pub fn method_parser(input: &[u8]) -> IResult<&[u8], MethodInfo> {
-    do_parse!(
+    let (input, access_flags) = be_u16(input)?;
+    let (input, name_index) = be_u16(input)?;
+    let (input, descriptor_index) = be_u16(input)?;
+    let (input, attributes_count) = be_u16(input)?;
+    let (input, attributes) = count(attribute_parser, attributes_count as usize)(input)?;
+    Ok((
         input,
-        access_flags: be_u16
-            >> name_index: be_u16
-            >> descriptor_index: be_u16
-            >> attributes_count: be_u16
-            >> attributes: count!(attribute_parser, attributes_count as usize)
-            >> (MethodInfo {
-                access_flags: MethodAccessFlags::from_bits_truncate(access_flags),
-                name_index,
-                descriptor_index,
-                attributes_count,
-                attributes,
-            })
-    )
+        MethodInfo {
+            access_flags: MethodAccessFlags::from_bits_truncate(access_flags),
+            name_index,
+            descriptor_index,
+            attributes_count,
+            attributes,
+        },
+    ))
 }


### PR DESCRIPTION
Currently, using classfile-parser results in `cargo audit` complaining a little bit about a transitive dependency of the old nom.

```
Crate:     lexical-core
Version:   0.7.6
Warning:   unsound
Title:     Multiple soundness issues
Date:      2023-09-03
ID:        RUSTSEC-2023-0086
URL:       https://rustsec.org/advisories/RUSTSEC-2023-0086
Dependency tree:
lexical-core 0.7.6
└── nom 5.1.3
    └── classfile-parser 0.3.8
```

Sadly, the upgrade is far from small, since nom 7 removed macros.