### PR TITLE
Fix broken sourcefile_attribute_parser

### DIFF
--- a/src/attribute_info/parser.rs
+++ b/src/attribute_info/parser.rs
@@ -288,15 +288,6 @@ pub fn bootstrap_methods_attribute_parser(
 pub fn sourcefile_attribute_parser(
     input: &[u8],
 ) -> Result<(&[u8], SourceFileAttribute), Err<&[u8]>> {
-    let (input, attribute_name_index) = be_u16(input)?;
-    let (input, attribute_length) = be_u32(input)?;
     let (input, sourcefile_index) = be_u16(input)?;
-    Ok((
-        input,
-        SourceFileAttribute {
-            attribute_name_index,
-            attribute_length,
-            sourcefile_index,
-        },
-    ))
+    Ok((input, SourceFileAttribute { sourcefile_index }))
 }

--- a/src/attribute_info/types.rs
+++ b/src/attribute_info/types.rs
@@ -130,12 +130,6 @@ pub struct BootstrapMethodsAttribute {
 /// [see more](https://docs.oracle.com/javase/specs/jvms/se8/html/jvms-4.html#jvms-4.7.10)
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct SourceFileAttribute {
-    /// The value of the attribute_name_index item must be a valid index into the constant_pool table.
-    /// The constant_pool entry at that index must be a CONSTANT_Utf8_info structure
-    /// representing the string "SourceFile".
-    pub attribute_name_index: u16,
-    /// The value of the attribute_length item must be two.
-    pub attribute_length: u32,
     /// The value of the sourcefile_index item must be a valid index into the constant_pool table.
     /// The constant_pool entry at that index must be a CONSTANT_Utf8_info structure representing a string.
     pub sourcefile_index: u16,

--- a/tests/code_attribute.rs
+++ b/tests/code_attribute.rs
@@ -173,3 +173,31 @@ fn local_variable_table() {
         ]
     );
 }
+
+#[test]
+fn source_file() {
+    let class_bytes = include_bytes!("../java-assets/compiled-classes/BasicClass.class");
+    let (_, class) = class_parser(class_bytes).unwrap();
+
+    let source = class
+        .attributes
+        .iter()
+        .find_map(|attribute_info| {
+            match lookup_string(&class, attribute_info.attribute_name_index)?.as_str() {
+                "SourceFile" => classfile_parser::attribute_info::sourcefile_attribute_parser(
+                    &attribute_info.info,
+                )
+                .ok(),
+                o => {
+                    dbg!(o);
+                    None
+                }
+            }
+        })
+        .map(|i| i.1)
+        .unwrap();
+
+    let s = lookup_string(&class, source.sourcefile_index).unwrap();
+
+    assert_eq!(s, "BasicClass.java");
+}


### PR DESCRIPTION
Remove parsing of attribute_name_index and attribute_length from sourcefile_attribute_parser.
These fields don't need to be parsed here.