### PR TITLE
Add DynamicConstant

### DIFF
--- a/src/constant_info/parser.rs
+++ b/src/constant_info/parser.rs
@@ -119,6 +119,18 @@ fn const_method_type(input: &[u8]) -> ConstantInfoResult<'_> {
     ))
 }
 
+fn const_dynamic(input: &[u8]) -> ConstantInfoResult<'_> {
+    let (input, bootstrap_method_attr_index) = be_u16(input)?;
+    let (input, name_and_type_index) = be_u16(input)?;
+    Ok((
+        input,
+        ConstantInfo::Dynamic(DynamicConstant {
+            bootstrap_method_attr_index,
+            name_and_type_index,
+        }),
+    ))
+}
+
 fn const_invoke_dynamic(input: &[u8]) -> ConstantInfoResult<'_> {
     let (input, bootstrap_method_attr_index) = be_u16(input)?;
     let (input, name_and_type_index) = be_u16(input)?;
@@ -159,6 +171,7 @@ fn const_block_parser(input: &[u8], const_type: u8) -> ConstantInfoResult<'_> {
         12 => const_name_and_type(input),
         15 => const_method_handle(input),
         16 => const_method_type(input),
+        17 => const_dynamic(input),
         18 => const_invoke_dynamic(input),
         19 => const_module(input),
         20 => const_package(input),

--- a/src/constant_info/types.rs
+++ b/src/constant_info/types.rs
@@ -16,6 +16,7 @@ pub enum ConstantInfo {
     NameAndType(NameAndTypeConstant),
     MethodHandle(MethodHandleConstant),
     MethodType(MethodTypeConstant),
+    Dynamic(DynamicConstant),
     InvokeDynamic(InvokeDynamicConstant),
     Module(ModuleConstant),
     Package(PackageConstant),
@@ -104,6 +105,13 @@ pub struct MethodHandleConstant {
 #[binrw]
 pub struct MethodTypeConstant {
     pub descriptor_index: u16,
+}
+
+#[derive(Clone, Debug)]
+#[binrw]
+pub struct DynamicConstant {
+    pub bootstrap_method_attr_index: u16,
+    pub name_and_type_index: u16,
 }
 
 #[derive(Clone, Debug)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -34,7 +34,7 @@ pub fn class_parser(input: &[u8]) -> IResult<&[u8], ClassFile> {
     let (input, minor_version) = be_u16(input)?;
     let (input, major_version) = be_u16(input)?;
     let (input, const_pool_size) = be_u16(input)?;
-    let (input, const_pool) = constant_parser(input, (const_pool_size - 1) as usize)?;
+    let (input, const_pool) = constant_parser(input, (const_pool_size.saturating_sub(1)) as usize)?;
     let (input, access_flags) = be_u16(input)?;
     let (input, this_class) = be_u16(input)?;
     let (input, super_class) = be_u16(input)?;


### PR DESCRIPTION
1. DynamicConstant was not handled, witch resulted in an Error
    With this change it is possible to load all classes in jdk25.
2. Fuzzer found and integer underflow panic, with const_pool_size